### PR TITLE
[GEN-787] Update config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -128,7 +128,7 @@ uploads:
   NSCLC:
     DFCI:
       data1: syn25582436
-      header1: syn25582427
+      #header1: syn25582427
     MSK:
       data1: syn25557012
     UHN:
@@ -176,7 +176,7 @@ uploads:
   CRC:
     DFCI:
       data1: syn25961098
-      header1: syn25961099
+      #header1: syn25961099
     MSK:
       data1: syn25953196
     VICC:


### PR DESCRIPTION
Commenting out "header1" for DFCI NSCLC and CRC cohorts due to the site stopping use of the the header file for their uploads.