### PR TITLE
[GEN-936] Remove multi-file upload by DFCI CRC2

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -215,7 +215,6 @@ uploads:
   CRC2:
     DFCI:
       data1: syn29418170
-      data2: syn52623830
     DUKE:
       data1: syn30821496
     MSK:


### PR DESCRIPTION
[GEN-936]: https://sagebionetworks.jira.com/browse/GEN-936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

We would like to standardize the pipeline to accept one file at the upload. In order to do that, we will need to remove the multi-file structure that was set up for DFCI's upload.

To-do:

- [x] Remove data2 synID for CRC2 DFCI: revert previous commit that add data2 synID to CRC2 DFCI ([GEN-904])

[GEN-904]: https://sagebionetworks.jira.com/browse/GEN-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ