### PR TITLE
[GEN-2367] Update NA to NULLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ git clone git@github.com:Sage-Bionetworks/genie-bpc-quac.git
 cd genie-bpc-quac/
 ```
 
-For installation with Docker: 
+For installation with Docker:
+
+**NOTE:** The Dockerfile is too old to build from scratch (due to outdated R etc), but because the Dockerhub images caches and if we only make code changes, it will just rebuild successfully from the code change step since that's one of the last steps. So we have to just pull down the docker image from Dockerhub instead to run the code.
 
 ```
-docker build -t genie-bpc-quac .
+docker pull sagebionetworks/genie-bpc-quac
 ```
 
-For install without Docker, install Synapser and other required packages. **NOTE** It is highly recommended you use the same `synapser` version that the Docker image has or just use the Docker image itself:
+For install without Docker, install Synapser and other required packages. **It is HIGHLY recommended you use the same `synapser` version that the Docker image has or just use the Docker image itself**:
 ```
 R -e 'install.packages("synapser", repos = c("http://ran.synapse.org", "http://cran.fhcrc.org"))'
 R -e 'renv::restore()'
@@ -30,19 +32,20 @@ R -e 'renv::restore()'
 
 ## Usage 
 
+
+To run with Docker, first activate the Docker image in interactive mode:
+
+```
+docker run -it --rm sagebionetworks/genie-bpc-quac /bin/bash
+```
+
 Make sure to cache your Synapse personal access token (PAT) as an environmental variable:
 
 ```
 export SYNAPSE_AUTH_TOKEN={your_personal_access_token_here}
 ```
 
-To run with Docker:
-
-```
-docker run --rm genie-bpc-quac -h
-```
-
-To run without Docker:
+To run the actual code with or without a Docker image:
 
 ```
 Rscript genie-bpc-quac.R -h
@@ -77,13 +80,7 @@ optional arguments:
                         '~/.synapseConfig')
 ```
 
-Example command line with Docker:
-
-```
-docker run --rm genie-bpc-quac -c {cohort} -s {site} -r upload -l error -v -a $SYNAPSE_AUTH_TOKEN
-```
-
-Example command line without Docker:
+Example command line:
 
 ```
 Rscript genie-bpc-quac.R -c {cohort} -s {site} -r upload -l error -v -a $SYNAPSE_AUTH_TOKEN

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For installation with Docker:
 docker build -t genie-bpc-quac .
 ```
 
-For install without Docker, install Synapser and other required packages:
+For install without Docker, install Synapser and other required packages. **NOTE** It is highly recommended you use the same `synapser` version that the Docker image has or just use the Docker image itself:
 ```
 R -e 'install.packages("synapser", repos = c("http://ran.synapse.org", "http://cran.fhcrc.org"))'
 R -e 'renv::restore()'

--- a/fxns.R
+++ b/fxns.R
@@ -85,7 +85,7 @@ get_synid_from_table <- function(synid, condition = NA, with_names = F) {
 #' @return Data frame repereneting stored at the Synapse ID entity.
 #' @example
 #' get_data(synid = "syn12345", version = 1)
-get_data <- function(synid, version = NA, sheet = 1) {
+get_data <- function(synid, version = NULL, sheet = 1) {
 
   # determine synapse id data type and query table or read csv
   if (is_synapse_table(synid)) {
@@ -116,7 +116,7 @@ get_data <- function(synid, version = NA, sheet = 1) {
 }
 
 get_data_filtered_table <- function(synid, column_name, col_value, select = NA,
-                                    version = NA, exact = F) {
+                                    version = NULL, exact = F) {
   
   # filter with where clause
   where_clause <- ""
@@ -159,7 +159,7 @@ get_data_filtered_table <- function(synid, column_name, col_value, select = NA,
 }
 
 get_data_filtered_file <- function(synid, column_name, col_value, select = NA,
-                                   version = NA, exact = F) {
+                                   version = NULL, exact = F) {
   
   ent <- synGet(as.character(synid), version = version)
   data <- read.csv(ent$path, check.names = F, na.strings = c(""),
@@ -207,7 +207,7 @@ get_data_filtered_file <- function(synid, column_name, col_value, select = NA,
 #' (synid = "syn12345", column_name = c("cohort", "record_id"),
 #' col_value = c("my_favorite_cohort", "-my_favorite_site-"), exact = c(T,F))
 get_data_filtered <- function(synid, column_name, col_value, select,
-                              version = NA, exact = F) {
+                              version = NULL, exact = F) {
 
   # determine synapse id data type and query table or read csv
   if (is_synapse_table(synid)) {


### PR DESCRIPTION
# **Problem:**
In `synapser` >= 1.0, [type conversions have become nuanced since using reticulate](https://r-docs.synapse.org/articles/troubleshooting.html#type-conversions) and `NA` in R evaluates to `True` in Python. This causes all of the version parameters in function calls to get data from Synapse to evaluate to 1 which is not what we want. 

# **Solution:**
Update all calls that gets data from Synapse and takes a version parameter to set to `NULL` if not specified. This is now a fix that should work across all `synapser` versions.

# **Testing:**

- [x] Test on BPC data with cohort BrCa that only has a version 2 in their files on `synapser 2.1.1`
- [x] Test on BPC data with cohort BrCa on the R docker image using the **old code** for this repo which uses `synapser` < 1.0: `sagebionetworks/genie-bpc-quac`. Was able to generate report here: https://www.synapse.org/Synapse:syn53507282.3
- [X] Test on BPC data with cohort BrCa on the R docker image  using the **new code on this branch** for this repo which uses `synapser` < 1.0: `sagebionetworks/genie-bpc-quac`. Was able to generate report here: https://www.synapse.org/Synapse:syn53507282.2
- [x] Check that report ran on old code equals report ran on new code in `synapser` < 1.0 report
- [x] Check that the report on `synapser 2.1.1` equals the `synapser` < 1.0 report